### PR TITLE
Result of running pnpm lint:fix

### DIFF
--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -19,7 +19,10 @@ library ECDSA {
      * @param signature signed data payload
      * @return recovered message signer
      */
-    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+    function recover(
+        bytes32 hash,
+        bytes memory signature
+    ) internal pure returns (address) {
         if (signature.length != 65) revert("ECDSA: Invalid Signature Length");
 
         bytes32 r;
@@ -43,7 +46,12 @@ library ECDSA {
      * @param s signature "s" value
      * @return recovered message signer
      */
-    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+    function recover(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal pure returns (address) {
         // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
         // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
         // the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
@@ -53,7 +61,10 @@ library ECDSA {
         // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
         // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
         // these malleable signatures as well.
-        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) revert("ECDSA: Invalid S");
+        if (
+            uint256(s) >
+            0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0
+        ) revert("ECDSA: Invalid S");
         if (v != 27 && v != 28) revert("ECDSA: Invalid V");
 
         // If the signature is valid (and not malleable), return the signer address
@@ -68,7 +79,12 @@ library ECDSA {
      * @param hash hashed data payload
      * @return signed message hash
      */
-    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    function toEthSignedMessageHash(
+        bytes32 hash
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)
+            );
     }
 }

--- a/contracts/cryptography/EIP712.sol
+++ b/contracts/cryptography/EIP712.sol
@@ -9,7 +9,9 @@ pragma solidity 0.8.26;
  */
 library EIP712 {
     bytes32 internal constant EIP712_TYPE_HASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+        keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
 
     /**
      * @notice calculate unique EIP-712 domain separator

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -15,7 +15,11 @@ library MerkleProof {
      * @param leaf element whose presence in Merkle tree to prove
      * @return whether leaf is proven to be contained within Merkle tree defined by root
      */
-    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
+    function verify(
+        bytes32[] memory proof,
+        bytes32 root,
+        bytes32 leaf
+    ) internal pure returns (bool) {
         unchecked {
             bytes32 computedHash = leaf;
 
@@ -23,9 +27,13 @@ library MerkleProof {
                 bytes32 proofElement = proof[i];
 
                 if (computedHash <= proofElement) {
-                    computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
+                    computedHash = keccak256(
+                        abi.encodePacked(computedHash, proofElement)
+                    );
                 } else {
-                    computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+                    computedHash = keccak256(
+                        abi.encodePacked(proofElement, computedHash)
+                    );
                 }
             }
 

--- a/contracts/data/BinaryHeap.sol
+++ b/contracts/data/BinaryHeap.sol
@@ -26,39 +26,66 @@ library BinaryHeap {
         Heap _inner;
     }
 
-    function at(Bytes32Heap storage heap, uint256 index) internal view returns (bytes32) {
+    function at(
+        Bytes32Heap storage heap,
+        uint256 index
+    ) internal view returns (bytes32) {
         return _at(heap._inner, index);
     }
 
-    function at(AddressHeap storage heap, uint256 index) internal view returns (address) {
+    function at(
+        AddressHeap storage heap,
+        uint256 index
+    ) internal view returns (address) {
         return address(uint160(uint256(_at(heap._inner, index))));
     }
 
-    function at(UintHeap storage heap, uint256 index) internal view returns (uint256) {
+    function at(
+        UintHeap storage heap,
+        uint256 index
+    ) internal view returns (uint256) {
         return uint256(_at(heap._inner, index));
     }
 
-    function contains(Bytes32Heap storage heap, bytes32 value) internal view returns (bool) {
+    function contains(
+        Bytes32Heap storage heap,
+        bytes32 value
+    ) internal view returns (bool) {
         return _contains(heap._inner, value);
     }
 
-    function contains(AddressHeap storage heap, address value) internal view returns (bool) {
+    function contains(
+        AddressHeap storage heap,
+        address value
+    ) internal view returns (bool) {
         return _contains(heap._inner, bytes32(uint256(uint160(value))));
     }
 
-    function contains(UintHeap storage heap, uint256 value) internal view returns (bool) {
+    function contains(
+        UintHeap storage heap,
+        uint256 value
+    ) internal view returns (bool) {
         return _contains(heap._inner, bytes32(value));
     }
 
-    function indexOf(Bytes32Heap storage heap, bytes32 value) internal view returns (uint256) {
+    function indexOf(
+        Bytes32Heap storage heap,
+        bytes32 value
+    ) internal view returns (uint256) {
         return _indexOf(heap._inner, value);
     }
 
-    function indexOf(AddressHeap storage heap, address value) internal view returns (uint256) {
+    function indexOf(
+        AddressHeap storage heap,
+        address value
+    ) internal view returns (uint256) {
         return _indexOf(heap._inner, bytes32(uint256(uint160(value))));
     }
 
-    function indexOf(UintHeap storage heap, uint256 value) internal view returns (uint256) {
+    function indexOf(
+        UintHeap storage heap,
+        uint256 value
+    ) internal view returns (uint256) {
         return _indexOf(heap._inner, bytes32(value));
     }
 
@@ -86,11 +113,17 @@ library BinaryHeap {
         return uint256(_root(heap._inner));
     }
 
-    function add(Bytes32Heap storage heap, bytes32 value) internal returns (bool) {
+    function add(
+        Bytes32Heap storage heap,
+        bytes32 value
+    ) internal returns (bool) {
         return _add(heap._inner, value);
     }
 
-    function add(AddressHeap storage heap, address value) internal returns (bool) {
+    function add(
+        AddressHeap storage heap,
+        address value
+    ) internal returns (bool) {
         return _add(heap._inner, bytes32(uint256(uint160(value))));
     }
 
@@ -98,23 +131,36 @@ library BinaryHeap {
         return _add(heap._inner, bytes32(value));
     }
 
-    function remove(Bytes32Heap storage heap, bytes32 value) internal returns (bool) {
+    function remove(
+        Bytes32Heap storage heap,
+        bytes32 value
+    ) internal returns (bool) {
         return _remove(heap._inner, value);
     }
 
-    function remove(AddressHeap storage heap, address value) internal returns (bool) {
+    function remove(
+        AddressHeap storage heap,
+        address value
+    ) internal returns (bool) {
         return _remove(heap._inner, bytes32(uint256(uint160(value))));
     }
 
-    function remove(UintHeap storage heap, uint256 value) internal returns (bool) {
+    function remove(
+        UintHeap storage heap,
+        uint256 value
+    ) internal returns (bool) {
         return _remove(heap._inner, bytes32(value));
     }
 
-    function toArray(Bytes32Heap storage heap) internal view returns (bytes32[] memory) {
+    function toArray(
+        Bytes32Heap storage heap
+    ) internal view returns (bytes32[] memory) {
         return heap._inner._values;
     }
 
-    function toArray(AddressHeap storage heap) internal view returns (address[] memory) {
+    function toArray(
+        AddressHeap storage heap
+    ) internal view returns (address[] memory) {
         bytes32[] storage values = heap._inner._values;
         address[] storage array;
 
@@ -125,7 +171,9 @@ library BinaryHeap {
         return array;
     }
 
-    function toArray(UintHeap storage heap) internal view returns (uint256[] memory) {
+    function toArray(
+        UintHeap storage heap
+    ) internal view returns (uint256[] memory) {
         bytes32[] storage values = heap._inner._values;
         uint256[] storage array;
 
@@ -136,15 +184,24 @@ library BinaryHeap {
         return array;
     }
 
-    function _at(Heap storage heap, uint256 index) private view returns (bytes32) {
+    function _at(
+        Heap storage heap,
+        uint256 index
+    ) private view returns (bytes32) {
         return heap._values[index];
     }
 
-    function _contains(Heap storage heap, bytes32 value) private view returns (bool) {
+    function _contains(
+        Heap storage heap,
+        bytes32 value
+    ) private view returns (bool) {
         return heap._indexes[value] != 0;
     }
 
-    function _indexOf(Heap storage heap, bytes32 value) private view returns (uint256) {
+    function _indexOf(
+        Heap storage heap,
+        bytes32 value
+    ) private view returns (uint256) {
         unchecked {
             return heap._indexes[value] - 1;
         }
@@ -158,7 +215,10 @@ library BinaryHeap {
         return _at(heap, 0);
     }
 
-    function _add(Heap storage heap, bytes32 value) private returns (bool update) {
+    function _add(
+        Heap storage heap,
+        bytes32 value
+    ) private returns (bool update) {
         if (!_contains(heap, value)) {
             heap._values.push(value);
             heap._indexes[value] = _length(heap);
@@ -168,7 +228,10 @@ library BinaryHeap {
         }
     }
 
-    function _remove(Heap storage heap, bytes32 value) private returns (bool update) {
+    function _remove(
+        Heap storage heap,
+        bytes32 value
+    ) private returns (bool update) {
         if (_contains(heap, value)) {
             uint256 index = _indexOf(heap, value);
 
@@ -196,7 +259,11 @@ library BinaryHeap {
         }
     }
 
-    function _maxHeapify(Heap storage heap, uint256 len, uint256 index) private {
+    function _maxHeapify(
+        Heap storage heap,
+        uint256 len,
+        uint256 index
+    ) private {
         uint256 largest = index;
         bytes32[] storage values = heap._values;
 

--- a/contracts/data/DoublyLinkedList.sol
+++ b/contracts/data/DoublyLinkedList.sol
@@ -34,39 +34,80 @@ library DoublyLinkedList {
      */
     error DoublyLinkedList__NonExistentEntry();
 
-    function contains(Bytes32List storage self, bytes32 value) internal view returns (bool) {
+    function contains(
+        Bytes32List storage self,
+        bytes32 value
+    ) internal view returns (bool) {
         return _contains(self._inner, value);
     }
 
-    function contains(AddressList storage self, address value) internal view returns (bool) {
+    function contains(
+        AddressList storage self,
+        address value
+    ) internal view returns (bool) {
         return _contains(self._inner, bytes32(uint256(uint160(value))));
     }
 
-    function contains(Uint256List storage self, uint256 value) internal view returns (bool) {
+    function contains(
+        Uint256List storage self,
+        uint256 value
+    ) internal view returns (bool) {
         return _contains(self._inner, bytes32(value));
     }
 
-    function prev(Bytes32List storage self, bytes32 value) internal view returns (bytes32) {
+    function prev(
+        Bytes32List storage self,
+        bytes32 value
+    ) internal view returns (bytes32) {
         return _prev(self._inner, value);
     }
 
-    function prev(AddressList storage self, address value) internal view returns (address) {
-        return address(uint160(uint256(_prev(self._inner, bytes32(uint256(uint160(value)))))));
+    function prev(
+        AddressList storage self,
+        address value
+    ) internal view returns (address) {
+        return
+            address(
+                uint160(
+                    uint256(
+                        _prev(self._inner, bytes32(uint256(uint160(value))))
+                    )
+                )
+            );
     }
 
-    function prev(Uint256List storage self, uint256 value) internal view returns (uint256) {
+    function prev(
+        Uint256List storage self,
+        uint256 value
+    ) internal view returns (uint256) {
         return uint256(_prev(self._inner, bytes32(value)));
     }
 
-    function next(Bytes32List storage self, bytes32 value) internal view returns (bytes32) {
+    function next(
+        Bytes32List storage self,
+        bytes32 value
+    ) internal view returns (bytes32) {
         return _next(self._inner, value);
     }
 
-    function next(AddressList storage self, address value) internal view returns (address) {
-        return address(uint160(uint256(_next(self._inner, bytes32(uint256(uint160(value)))))));
+    function next(
+        AddressList storage self,
+        address value
+    ) internal view returns (address) {
+        return
+            address(
+                uint160(
+                    uint256(
+                        _next(self._inner, bytes32(uint256(uint160(value))))
+                    )
+                )
+            );
     }
 
-    function next(Uint256List storage self, uint256 value) internal view returns (uint256) {
+    function next(
+        Uint256List storage self,
+        uint256 value
+    ) internal view returns (uint256) {
         return uint256(_next(self._inner, bytes32(value)));
     }
 
@@ -83,7 +124,11 @@ library DoublyLinkedList {
         address nextValue,
         address newValue
     ) internal returns (bool status) {
-        status = _insertBefore(self._inner, bytes32(uint256(uint160(nextValue))), bytes32(uint256(uint160(newValue))));
+        status = _insertBefore(
+            self._inner,
+            bytes32(uint256(uint160(nextValue))),
+            bytes32(uint256(uint160(newValue)))
+        );
     }
 
     function insertBefore(
@@ -91,30 +136,63 @@ library DoublyLinkedList {
         uint256 nextValue,
         uint256 newValue
     ) internal returns (bool status) {
-        status = _insertBefore(self._inner, bytes32(nextValue), bytes32(newValue));
+        status = _insertBefore(
+            self._inner,
+            bytes32(nextValue),
+            bytes32(newValue)
+        );
     }
 
-    function insertAfter(Bytes32List storage self, bytes32 prevValue, bytes32 newValue) internal returns (bool status) {
+    function insertAfter(
+        Bytes32List storage self,
+        bytes32 prevValue,
+        bytes32 newValue
+    ) internal returns (bool status) {
         status = _insertAfter(self._inner, prevValue, newValue);
     }
 
-    function insertAfter(AddressList storage self, address prevValue, address newValue) internal returns (bool status) {
-        status = _insertAfter(self._inner, bytes32(uint256(uint160(prevValue))), bytes32(uint256(uint160(newValue))));
+    function insertAfter(
+        AddressList storage self,
+        address prevValue,
+        address newValue
+    ) internal returns (bool status) {
+        status = _insertAfter(
+            self._inner,
+            bytes32(uint256(uint160(prevValue))),
+            bytes32(uint256(uint160(newValue)))
+        );
     }
 
-    function insertAfter(Uint256List storage self, uint256 prevValue, uint256 newValue) internal returns (bool status) {
-        status = _insertAfter(self._inner, bytes32(prevValue), bytes32(newValue));
+    function insertAfter(
+        Uint256List storage self,
+        uint256 prevValue,
+        uint256 newValue
+    ) internal returns (bool status) {
+        status = _insertAfter(
+            self._inner,
+            bytes32(prevValue),
+            bytes32(newValue)
+        );
     }
 
-    function push(Bytes32List storage self, bytes32 value) internal returns (bool status) {
+    function push(
+        Bytes32List storage self,
+        bytes32 value
+    ) internal returns (bool status) {
         status = _push(self._inner, value);
     }
 
-    function push(AddressList storage self, address value) internal returns (bool status) {
+    function push(
+        AddressList storage self,
+        address value
+    ) internal returns (bool status) {
         status = _push(self._inner, bytes32(uint256(uint160(value))));
     }
 
-    function push(Uint256List storage self, uint256 value) internal returns (bool status) {
+    function push(
+        Uint256List storage self,
+        uint256 value
+    ) internal returns (bool status) {
         status = _push(self._inner, bytes32(value));
     }
 
@@ -142,56 +220,107 @@ library DoublyLinkedList {
         value = uint256(_shift(self._inner));
     }
 
-    function unshift(Bytes32List storage self, bytes32 value) internal returns (bool status) {
+    function unshift(
+        Bytes32List storage self,
+        bytes32 value
+    ) internal returns (bool status) {
         status = _unshift(self._inner, value);
     }
 
-    function unshift(AddressList storage self, address value) internal returns (bool status) {
+    function unshift(
+        AddressList storage self,
+        address value
+    ) internal returns (bool status) {
         status = _unshift(self._inner, bytes32(uint256(uint160(value))));
     }
 
-    function unshift(Uint256List storage self, uint256 value) internal returns (bool status) {
+    function unshift(
+        Uint256List storage self,
+        uint256 value
+    ) internal returns (bool status) {
         status = _unshift(self._inner, bytes32(value));
     }
 
-    function remove(Bytes32List storage self, bytes32 value) internal returns (bool status) {
+    function remove(
+        Bytes32List storage self,
+        bytes32 value
+    ) internal returns (bool status) {
         status = _remove(self._inner, value);
     }
 
-    function remove(AddressList storage self, address value) internal returns (bool status) {
+    function remove(
+        AddressList storage self,
+        address value
+    ) internal returns (bool status) {
         status = _remove(self._inner, bytes32(uint256(uint160(value))));
     }
 
-    function remove(Uint256List storage self, uint256 value) internal returns (bool status) {
+    function remove(
+        Uint256List storage self,
+        uint256 value
+    ) internal returns (bool status) {
         status = _remove(self._inner, bytes32(value));
     }
 
-    function replace(Bytes32List storage self, bytes32 oldValue, bytes32 newValue) internal returns (bool status) {
+    function replace(
+        Bytes32List storage self,
+        bytes32 oldValue,
+        bytes32 newValue
+    ) internal returns (bool status) {
         status = _replace(self._inner, oldValue, newValue);
     }
 
-    function replace(AddressList storage self, address oldValue, address newValue) internal returns (bool status) {
-        status = _replace(self._inner, bytes32(uint256(uint160(oldValue))), bytes32(uint256(uint160(newValue))));
+    function replace(
+        AddressList storage self,
+        address oldValue,
+        address newValue
+    ) internal returns (bool status) {
+        status = _replace(
+            self._inner,
+            bytes32(uint256(uint160(oldValue))),
+            bytes32(uint256(uint160(newValue)))
+        );
     }
 
-    function replace(Uint256List storage self, uint256 oldValue, uint256 newValue) internal returns (bool status) {
+    function replace(
+        Uint256List storage self,
+        uint256 oldValue,
+        uint256 newValue
+    ) internal returns (bool status) {
         status = _replace(self._inner, bytes32(oldValue), bytes32(newValue));
     }
 
-    function _contains(DoublyLinkedListInternal storage self, bytes32 value) private view returns (bool) {
-        return value != 0 && (self._nextValues[value] != 0 || self._prevValues[0] == value);
+    function _contains(
+        DoublyLinkedListInternal storage self,
+        bytes32 value
+    ) private view returns (bool) {
+        return
+            value != 0 &&
+            (self._nextValues[value] != 0 || self._prevValues[0] == value);
     }
 
-    function _prev(DoublyLinkedListInternal storage self, bytes32 nextValue) private view returns (bytes32 prevValue) {
+    function _prev(
+        DoublyLinkedListInternal storage self,
+        bytes32 nextValue
+    ) private view returns (bytes32 prevValue) {
         prevValue = self._prevValues[nextValue];
-        if (nextValue != 0 && prevValue == 0 && _next(self, prevValue) != nextValue)
-            revert("DoublyLinkedList: Non Existent Entry");
+        if (
+            nextValue != 0 &&
+            prevValue == 0 &&
+            _next(self, prevValue) != nextValue
+        ) revert("DoublyLinkedList: Non Existent Entry");
     }
 
-    function _next(DoublyLinkedListInternal storage self, bytes32 prevValue) private view returns (bytes32 nextValue) {
+    function _next(
+        DoublyLinkedListInternal storage self,
+        bytes32 prevValue
+    ) private view returns (bytes32 nextValue) {
         nextValue = self._nextValues[prevValue];
-        if (prevValue != 0 && nextValue == 0 && _prev(self, nextValue) != prevValue)
-            revert("DoublyLinkedList: Non Existent Entry");
+        if (
+            prevValue != 0 &&
+            nextValue == 0 &&
+            _prev(self, nextValue) != prevValue
+        ) revert("DoublyLinkedList: Non Existent Entry");
     }
 
     function _insertBefore(
@@ -199,7 +328,12 @@ library DoublyLinkedList {
         bytes32 nextValue,
         bytes32 newValue
     ) private returns (bool status) {
-        status = _insertBetween(self, _prev(self, nextValue), nextValue, newValue);
+        status = _insertBetween(
+            self,
+            _prev(self, nextValue),
+            nextValue,
+            newValue
+        );
     }
 
     function _insertAfter(
@@ -207,7 +341,12 @@ library DoublyLinkedList {
         bytes32 prevValue,
         bytes32 newValue
     ) private returns (bool status) {
-        status = _insertBetween(self, prevValue, _next(self, prevValue), newValue);
+        status = _insertBetween(
+            self,
+            prevValue,
+            _next(self, prevValue),
+            newValue
+        );
     }
 
     function _insertBetween(
@@ -225,25 +364,38 @@ library DoublyLinkedList {
         }
     }
 
-    function _push(DoublyLinkedListInternal storage self, bytes32 value) private returns (bool status) {
+    function _push(
+        DoublyLinkedListInternal storage self,
+        bytes32 value
+    ) private returns (bool status) {
         status = _insertBetween(self, _prev(self, 0), 0, value);
     }
 
-    function _pop(DoublyLinkedListInternal storage self) private returns (bytes32 value) {
+    function _pop(
+        DoublyLinkedListInternal storage self
+    ) private returns (bytes32 value) {
         value = _prev(self, 0);
         _remove(self, value);
     }
 
-    function _shift(DoublyLinkedListInternal storage self) private returns (bytes32 value) {
+    function _shift(
+        DoublyLinkedListInternal storage self
+    ) private returns (bytes32 value) {
         value = _next(self, 0);
         _remove(self, value);
     }
 
-    function _unshift(DoublyLinkedListInternal storage self, bytes32 value) private returns (bool status) {
+    function _unshift(
+        DoublyLinkedListInternal storage self,
+        bytes32 value
+    ) private returns (bool status) {
         status = _insertBetween(self, 0, _next(self, 0), value);
     }
 
-    function _remove(DoublyLinkedListInternal storage self, bytes32 value) private returns (bool status) {
+    function _remove(
+        DoublyLinkedListInternal storage self,
+        bytes32 value
+    ) private returns (bool status) {
         if (_contains(self, value)) {
             _link(self, _prev(self, value), _next(self, value));
             delete self._prevValues[value];
@@ -257,9 +409,15 @@ library DoublyLinkedList {
         bytes32 oldValue,
         bytes32 newValue
     ) private returns (bool status) {
-        if (!_contains(self, oldValue)) revert("DoublyLinkedList: Non Existent Entry");
+        if (!_contains(self, oldValue))
+            revert("DoublyLinkedList: Non Existent Entry");
 
-        status = _insertBetween(self, _prev(self, oldValue), _next(self, oldValue), newValue);
+        status = _insertBetween(
+            self,
+            _prev(self, oldValue),
+            _next(self, oldValue),
+            newValue
+        );
 
         if (status) {
             delete self._prevValues[oldValue];
@@ -267,7 +425,11 @@ library DoublyLinkedList {
         }
     }
 
-    function _link(DoublyLinkedListInternal storage self, bytes32 prevValue, bytes32 nextValue) private {
+    function _link(
+        DoublyLinkedListInternal storage self,
+        bytes32 prevValue,
+        bytes32 nextValue
+    ) private {
         self._nextValues[prevValue] = nextValue;
         self._prevValues[nextValue] = prevValue;
     }

--- a/contracts/data/EnumerableMap.sol
+++ b/contracts/data/EnumerableMap.sol
@@ -30,60 +30,113 @@ library EnumerableMap {
         Map _inner;
     }
 
-    function at(AddressToAddressMap storage map, uint256 index) internal view returns (address, address) {
+    function at(
+        AddressToAddressMap storage map,
+        uint256 index
+    ) internal view returns (address, address) {
         (bytes32 key, bytes32 value) = _at(map._inner, index);
 
-        return (address(uint160(uint256(key))), address(uint160(uint256(value))));
+        return (
+            address(uint160(uint256(key))),
+            address(uint160(uint256(value)))
+        );
     }
 
-    function at(UintToAddressMap storage map, uint256 index) internal view returns (uint256, address) {
+    function at(
+        UintToAddressMap storage map,
+        uint256 index
+    ) internal view returns (uint256, address) {
         (bytes32 key, bytes32 value) = _at(map._inner, index);
         return (uint256(key), address(uint160(uint256(value))));
     }
 
-    function contains(AddressToAddressMap storage map, address key) internal view returns (bool) {
+    function contains(
+        AddressToAddressMap storage map,
+        address key
+    ) internal view returns (bool) {
         return _contains(map._inner, bytes32(uint256(uint160(key))));
     }
 
-    function contains(UintToAddressMap storage map, uint256 key) internal view returns (bool) {
+    function contains(
+        UintToAddressMap storage map,
+        uint256 key
+    ) internal view returns (bool) {
         return _contains(map._inner, bytes32(key));
     }
 
-    function length(AddressToAddressMap storage map) internal view returns (uint256) {
+    function length(
+        AddressToAddressMap storage map
+    ) internal view returns (uint256) {
         return _length(map._inner);
     }
 
-    function length(UintToAddressMap storage map) internal view returns (uint256) {
+    function length(
+        UintToAddressMap storage map
+    ) internal view returns (uint256) {
         return _length(map._inner);
     }
 
-    function get(AddressToAddressMap storage map, address key) internal view returns (address) {
-        return address(uint160(uint256(_get(map._inner, bytes32(uint256(uint160(key)))))));
+    function get(
+        AddressToAddressMap storage map,
+        address key
+    ) internal view returns (address) {
+        return
+            address(
+                uint160(
+                    uint256(_get(map._inner, bytes32(uint256(uint160(key)))))
+                )
+            );
     }
 
-    function get(UintToAddressMap storage map, uint256 key) internal view returns (address) {
+    function get(
+        UintToAddressMap storage map,
+        uint256 key
+    ) internal view returns (address) {
         return address(uint160(uint256(_get(map._inner, bytes32(key)))));
     }
 
-    function set(AddressToAddressMap storage map, address key, address value) internal returns (bool) {
-        return _set(map._inner, bytes32(uint256(uint160(key))), bytes32(uint256(uint160(value))));
+    function set(
+        AddressToAddressMap storage map,
+        address key,
+        address value
+    ) internal returns (bool) {
+        return
+            _set(
+                map._inner,
+                bytes32(uint256(uint160(key))),
+                bytes32(uint256(uint160(value)))
+            );
     }
 
-    function set(UintToAddressMap storage map, uint256 key, address value) internal returns (bool) {
+    function set(
+        UintToAddressMap storage map,
+        uint256 key,
+        address value
+    ) internal returns (bool) {
         return _set(map._inner, bytes32(key), bytes32(uint256(uint160(value))));
     }
 
-    function remove(AddressToAddressMap storage map, address key) internal returns (bool) {
+    function remove(
+        AddressToAddressMap storage map,
+        address key
+    ) internal returns (bool) {
         return _remove(map._inner, bytes32(uint256(uint160(key))));
     }
 
-    function remove(UintToAddressMap storage map, uint256 key) internal returns (bool) {
+    function remove(
+        UintToAddressMap storage map,
+        uint256 key
+    ) internal returns (bool) {
         return _remove(map._inner, bytes32(key));
     }
 
     function toArray(
         AddressToAddressMap storage map
-    ) internal view returns (address[] memory keysOut, address[] memory valuesOut) {
+    )
+        internal
+        view
+        returns (address[] memory keysOut, address[] memory valuesOut)
+    {
         uint256 len = map._inner._entries.length;
 
         keysOut = new address[](len);
@@ -91,15 +144,23 @@ library EnumerableMap {
 
         unchecked {
             for (uint256 i; i < len; ++i) {
-                keysOut[i] = address(uint160(uint256(map._inner._entries[i]._key)));
-                valuesOut[i] = address(uint160(uint256(map._inner._entries[i]._value)));
+                keysOut[i] = address(
+                    uint160(uint256(map._inner._entries[i]._key))
+                );
+                valuesOut[i] = address(
+                    uint160(uint256(map._inner._entries[i]._value))
+                );
             }
         }
     }
 
     function toArray(
         UintToAddressMap storage map
-    ) internal view returns (uint256[] memory keysOut, address[] memory valuesOut) {
+    )
+        internal
+        view
+        returns (uint256[] memory keysOut, address[] memory valuesOut)
+    {
         uint256 len = map._inner._entries.length;
 
         keysOut = new uint256[](len);
@@ -108,24 +169,32 @@ library EnumerableMap {
         unchecked {
             for (uint256 i; i < len; ++i) {
                 keysOut[i] = uint256(map._inner._entries[i]._key);
-                valuesOut[i] = address(uint160(uint256(map._inner._entries[i]._value)));
+                valuesOut[i] = address(
+                    uint160(uint256(map._inner._entries[i]._value))
+                );
             }
         }
     }
 
-    function keys(AddressToAddressMap storage map) internal view returns (address[] memory keysOut) {
+    function keys(
+        AddressToAddressMap storage map
+    ) internal view returns (address[] memory keysOut) {
         uint256 len = map._inner._entries.length;
 
         keysOut = new address[](len);
 
         unchecked {
             for (uint256 i; i < len; ++i) {
-                keysOut[i] = address(uint160(uint256(map._inner._entries[i]._key)));
+                keysOut[i] = address(
+                    uint160(uint256(map._inner._entries[i]._key))
+                );
             }
         }
     }
 
-    function keys(UintToAddressMap storage map) internal view returns (uint256[] memory keysOut) {
+    function keys(
+        UintToAddressMap storage map
+    ) internal view returns (uint256[] memory keysOut) {
         uint256 len = map._inner._entries.length;
 
         keysOut = new uint256[](len);
@@ -137,38 +206,53 @@ library EnumerableMap {
         }
     }
 
-    function values(AddressToAddressMap storage map) internal view returns (address[] memory valuesOut) {
+    function values(
+        AddressToAddressMap storage map
+    ) internal view returns (address[] memory valuesOut) {
         uint256 len = map._inner._entries.length;
 
         valuesOut = new address[](len);
 
         unchecked {
             for (uint256 i; i < len; ++i) {
-                valuesOut[i] = address(uint160(uint256(map._inner._entries[i]._value)));
+                valuesOut[i] = address(
+                    uint160(uint256(map._inner._entries[i]._value))
+                );
             }
         }
     }
 
-    function values(UintToAddressMap storage map) internal view returns (address[] memory valuesOut) {
+    function values(
+        UintToAddressMap storage map
+    ) internal view returns (address[] memory valuesOut) {
         uint256 len = map._inner._entries.length;
 
         valuesOut = new address[](len);
 
         unchecked {
             for (uint256 i; i < len; ++i) {
-                valuesOut[i] = address(uint160(uint256(map._inner._entries[i]._value)));
+                valuesOut[i] = address(
+                    uint160(uint256(map._inner._entries[i]._value))
+                );
             }
         }
     }
 
-    function _at(Map storage map, uint256 index) private view returns (bytes32, bytes32) {
-        if (index >= map._entries.length) revert("EnumerableMap: Index Out Of Bounds");
+    function _at(
+        Map storage map,
+        uint256 index
+    ) private view returns (bytes32, bytes32) {
+        if (index >= map._entries.length)
+            revert("EnumerableMap: Index Out Of Bounds");
 
         MapEntry storage entry = map._entries[index];
         return (entry._key, entry._value);
     }
 
-    function _contains(Map storage map, bytes32 key) private view returns (bool) {
+    function _contains(
+        Map storage map,
+        bytes32 key
+    ) private view returns (bool) {
         return map._indexes[key] != 0;
     }
 
@@ -184,7 +268,11 @@ library EnumerableMap {
         }
     }
 
-    function _set(Map storage map, bytes32 key, bytes32 value) private returns (bool) {
+    function _set(
+        Map storage map,
+        bytes32 key,
+        bytes32 value
+    ) private returns (bool) {
         uint256 keyIndex = map._indexes[key];
 
         if (keyIndex == 0) {

--- a/contracts/data/EnumerableSet.sol
+++ b/contracts/data/EnumerableSet.sol
@@ -28,39 +28,66 @@ library EnumerableSet {
         Set _inner;
     }
 
-    function at(Bytes32Set storage set, uint256 index) internal view returns (bytes32) {
+    function at(
+        Bytes32Set storage set,
+        uint256 index
+    ) internal view returns (bytes32) {
         return _at(set._inner, index);
     }
 
-    function at(AddressSet storage set, uint256 index) internal view returns (address) {
+    function at(
+        AddressSet storage set,
+        uint256 index
+    ) internal view returns (address) {
         return address(uint160(uint256(_at(set._inner, index))));
     }
 
-    function at(UintSet storage set, uint256 index) internal view returns (uint256) {
+    function at(
+        UintSet storage set,
+        uint256 index
+    ) internal view returns (uint256) {
         return uint256(_at(set._inner, index));
     }
 
-    function contains(Bytes32Set storage set, bytes32 value) internal view returns (bool) {
+    function contains(
+        Bytes32Set storage set,
+        bytes32 value
+    ) internal view returns (bool) {
         return _contains(set._inner, value);
     }
 
-    function contains(AddressSet storage set, address value) internal view returns (bool) {
+    function contains(
+        AddressSet storage set,
+        address value
+    ) internal view returns (bool) {
         return _contains(set._inner, bytes32(uint256(uint160(value))));
     }
 
-    function contains(UintSet storage set, uint256 value) internal view returns (bool) {
+    function contains(
+        UintSet storage set,
+        uint256 value
+    ) internal view returns (bool) {
         return _contains(set._inner, bytes32(value));
     }
 
-    function indexOf(Bytes32Set storage set, bytes32 value) internal view returns (uint256) {
+    function indexOf(
+        Bytes32Set storage set,
+        bytes32 value
+    ) internal view returns (uint256) {
         return _indexOf(set._inner, value);
     }
 
-    function indexOf(AddressSet storage set, address value) internal view returns (uint256) {
+    function indexOf(
+        AddressSet storage set,
+        address value
+    ) internal view returns (uint256) {
         return _indexOf(set._inner, bytes32(uint256(uint160(value))));
     }
 
-    function indexOf(UintSet storage set, uint256 value) internal view returns (uint256) {
+    function indexOf(
+        UintSet storage set,
+        uint256 value
+    ) internal view returns (uint256) {
         return _indexOf(set._inner, bytes32(value));
     }
 
@@ -76,11 +103,17 @@ library EnumerableSet {
         return _length(set._inner);
     }
 
-    function add(Bytes32Set storage set, bytes32 value) internal returns (bool) {
+    function add(
+        Bytes32Set storage set,
+        bytes32 value
+    ) internal returns (bool) {
         return _add(set._inner, value);
     }
 
-    function add(AddressSet storage set, address value) internal returns (bool) {
+    function add(
+        AddressSet storage set,
+        address value
+    ) internal returns (bool) {
         return _add(set._inner, bytes32(uint256(uint160(value))));
     }
 
@@ -88,23 +121,36 @@ library EnumerableSet {
         return _add(set._inner, bytes32(value));
     }
 
-    function remove(Bytes32Set storage set, bytes32 value) internal returns (bool) {
+    function remove(
+        Bytes32Set storage set,
+        bytes32 value
+    ) internal returns (bool) {
         return _remove(set._inner, value);
     }
 
-    function remove(AddressSet storage set, address value) internal returns (bool) {
+    function remove(
+        AddressSet storage set,
+        address value
+    ) internal returns (bool) {
         return _remove(set._inner, bytes32(uint256(uint160(value))));
     }
 
-    function remove(UintSet storage set, uint256 value) internal returns (bool) {
+    function remove(
+        UintSet storage set,
+        uint256 value
+    ) internal returns (bool) {
         return _remove(set._inner, bytes32(value));
     }
 
-    function toArray(Bytes32Set storage set) internal view returns (bytes32[] memory) {
+    function toArray(
+        Bytes32Set storage set
+    ) internal view returns (bytes32[] memory) {
         return set._inner._values;
     }
 
-    function toArray(AddressSet storage set) internal view returns (address[] memory) {
+    function toArray(
+        AddressSet storage set
+    ) internal view returns (address[] memory) {
         bytes32[] storage values = set._inner._values;
         address[] storage array;
 
@@ -115,7 +161,9 @@ library EnumerableSet {
         return array;
     }
 
-    function toArray(UintSet storage set) internal view returns (uint256[] memory) {
+    function toArray(
+        UintSet storage set
+    ) internal view returns (uint256[] memory) {
         bytes32[] storage values = set._inner._values;
         uint256[] storage array;
 
@@ -126,16 +174,26 @@ library EnumerableSet {
         return array;
     }
 
-    function _at(Set storage set, uint256 index) private view returns (bytes32) {
-        if (index >= set._values.length) revert("EnumerableSet: Index Out Of Bounds");
+    function _at(
+        Set storage set,
+        uint256 index
+    ) private view returns (bytes32) {
+        if (index >= set._values.length)
+            revert("EnumerableSet: Index Out Of Bounds");
         return set._values[index];
     }
 
-    function _contains(Set storage set, bytes32 value) private view returns (bool) {
+    function _contains(
+        Set storage set,
+        bytes32 value
+    ) private view returns (bool) {
         return set._indexes[value] != 0;
     }
 
-    function _indexOf(Set storage set, bytes32 value) private view returns (uint256) {
+    function _indexOf(
+        Set storage set,
+        bytes32 value
+    ) private view returns (uint256) {
         unchecked {
             return set._indexes[value] - 1;
         }
@@ -145,7 +203,10 @@ library EnumerableSet {
         return set._values.length;
     }
 
-    function _add(Set storage set, bytes32 value) private returns (bool status) {
+    function _add(
+        Set storage set,
+        bytes32 value
+    ) private returns (bool status) {
         if (!_contains(set, value)) {
             set._values.push(value);
             set._indexes[value] = set._values.length;
@@ -153,7 +214,10 @@ library EnumerableSet {
         }
     }
 
-    function _remove(Set storage set, bytes32 value) private returns (bool status) {
+    function _remove(
+        Set storage set,
+        bytes32 value
+    ) private returns (bool status) {
         uint256 valueIndex = set._indexes[value];
 
         if (valueIndex != 0) {

--- a/contracts/data/IncrementalMerkleTree.sol
+++ b/contracts/data/IncrementalMerkleTree.sol
@@ -46,7 +46,10 @@ library IncrementalMerkleTree {
         }
     }
 
-    function at(Tree storage t, uint256 index) internal view returns (bytes32 hash) {
+    function at(
+        Tree storage t,
+        uint256 index
+    ) internal view returns (bytes32 hash) {
         hash = t.nodes[0][index];
     }
 
@@ -151,7 +154,9 @@ library IncrementalMerkleTree {
                 // sibling is on the left
                 assembly {
                     mstore(0x00, row.slot)
-                    let sibling := sload(add(keccak256(0x00, 0x20), sub(colIndex, 1)))
+                    let sibling := sload(
+                        add(keccak256(0x00, 0x20), sub(colIndex, 1))
+                    )
                     mstore(0x00, sibling)
                     mstore(0x20, hash)
                     hash := keccak256(0x00, 0x40)
@@ -160,7 +165,9 @@ library IncrementalMerkleTree {
                 // sibling is on the right (and sibling exists)
                 assembly {
                     mstore(0x00, row.slot)
-                    let sibling := sload(add(keccak256(0x00, 0x20), add(colIndex, 1)))
+                    let sibling := sload(
+                        add(keccak256(0x00, 0x20), add(colIndex, 1))
+                    )
                     mstore(0x00, hash)
                     mstore(0x20, sibling)
                     hash := keccak256(0x00, 0x40)

--- a/contracts/initializable/IInitializable.sol
+++ b/contracts/initializable/IInitializable.sol
@@ -14,5 +14,7 @@ interface IInitializable is IInitializableInternal {
      * @param storageSlot_ The storage slot to check.
      * @return The {InitializationStatus} of the storage slot.
      */
-    function getInitializing(bytes32 storageSlot_) external view returns (InitializationStatus);
+    function getInitializing(
+        bytes32 storageSlot_
+    ) external view returns (InitializationStatus);
 }

--- a/contracts/initializable/Initializable.sol
+++ b/contracts/initializable/Initializable.sol
@@ -15,7 +15,9 @@ contract InitializablePackage is IInitializable, InitializableInternal {
     /**
      * @inheritdoc IInitializable
      */
-    function getInitializing(bytes32 storageSlot_) external view returns (InitializationStatus) {
+    function getInitializing(
+        bytes32 storageSlot_
+    ) external view returns (InitializationStatus) {
         return _getInitializing(storageSlot_);
     }
 }

--- a/contracts/initializable/InitializableInternal.sol
+++ b/contracts/initializable/InitializableInternal.sol
@@ -25,7 +25,9 @@ abstract contract InitializableInternal is IInitializableInternal {
     modifier initializer(bytes32 storageSlot_) {
         InitializableStorage.Layout storage $ = InitializableStorage.layout();
 
-        if ($.initialization[storageSlot_] != InitializationStatus.UnInitialized) {
+        if (
+            $.initialization[storageSlot_] != InitializationStatus.UnInitialized
+        ) {
             revert InitializableInvalidInitialization();
         }
 
@@ -69,7 +71,9 @@ abstract contract InitializableInternal is IInitializableInternal {
     function _disableInitializers(bytes32 storageSlot_) internal {
         InitializableStorage.Layout storage $ = InitializableStorage.layout();
 
-        if ($.initialization[storageSlot_] != InitializationStatus.UnInitialized) {
+        if (
+            $.initialization[storageSlot_] != InitializationStatus.UnInitialized
+        ) {
             revert InitializableInvalidInitialization();
         }
 
@@ -82,7 +86,9 @@ abstract contract InitializableInternal is IInitializableInternal {
      * @dev Internal function that returns the initialization status for the specified storage slot.
      * @param storageSlot_ The storage slot to check.
      */
-    function _getInitializing(bytes32 storageSlot_) internal view returns (InitializationStatus) {
+    function _getInitializing(
+        bytes32 storageSlot_
+    ) internal view returns (InitializationStatus) {
         InitializableStorage.Layout storage $ = InitializableStorage.layout();
 
         return $.initialization[storageSlot_];
@@ -91,9 +97,12 @@ abstract contract InitializableInternal is IInitializableInternal {
     /**
      * @dev Returns `true` if the contract is currently initializing. See {onlyInitializing}.
      */
-    function _isInitializing(bytes32 storageSlot_) internal view returns (bool) {
+    function _isInitializing(
+        bytes32 storageSlot_
+    ) internal view returns (bool) {
         InitializableStorage.Layout storage $ = InitializableStorage.layout();
 
-        return $.initialization[storageSlot_] == InitializationStatus.Initializing;
+        return
+            $.initialization[storageSlot_] == InitializationStatus.Initializing;
     }
 }

--- a/contracts/initializable/InitializableStorage.sol
+++ b/contracts/initializable/InitializableStorage.sol
@@ -24,7 +24,8 @@ library InitializableStorage {
      * @custom:storage-location erc7201:fevertokens.storage.Initializable
      */
     //
-    bytes32 internal constant STORAGE_SLOT = 0x300dbacb4eae624d21bf53d429940a1e327d6e579697456710cdaa5c67d1f900;
+    bytes32 internal constant STORAGE_SLOT =
+        0x300dbacb4eae624d21bf53d429940a1e327d6e579697456710cdaa5c67d1f900;
     //keccak256(abi.encode(uint256(keccak256("fevertokens.storage.Initializable")) - 1)) & ~bytes32(uint256(0xff));
 
     /**

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -8,7 +8,9 @@ import {ERC165Internal} from "./ERC165Internal.sol";
 
 contract ERC165 is IERC165, ERC165Internal {
     // @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external view returns (bool) {
         return _supportedInterface(interfaceId);
     }
 }

--- a/contracts/introspection/ERC165Internal.sol
+++ b/contracts/introspection/ERC165Internal.sol
@@ -7,12 +7,15 @@ import {IERC165Internal} from "./IERC165Internal.sol";
 import {ERC165Storage} from "./ERC165Storage.sol";
 
 abstract contract ERC165Internal is IERC165Internal {
-    function _supportedInterface(bytes4 interfaceId) internal view returns (bool) {
+    function _supportedInterface(
+        bytes4 interfaceId
+    ) internal view returns (bool) {
         return ERC165Storage.layout().supportedInterfaces[interfaceId];
     }
 
     function _setSupportedInterface(bytes4 interfaceId, bool status) internal {
-        if (interfaceId == 0xffffffff) revert("ERC165Base: Invalid InterfaceId");
+        if (interfaceId == 0xffffffff)
+            revert("ERC165Base: Invalid InterfaceId");
         ERC165Storage.layout().supportedInterfaces[interfaceId] = status;
     }
 }

--- a/contracts/introspection/ERC165Storage.sol
+++ b/contracts/introspection/ERC165Storage.sol
@@ -13,7 +13,8 @@ library ERC165Storage {
      * @custom:storage-location erc7201:fevertokens.storage.ERC165
      */
     //
-    bytes32 internal constant STORAGE_SLOT = 0xb5b8963eb69caba739dcbcf25496d25c11c82c55d18d8b19fd10f0dde3a5db00;
+    bytes32 internal constant STORAGE_SLOT =
+        0xb5b8963eb69caba739dcbcf25496d25c11c82c55d18d8b19fd10f0dde3a5db00;
     //  keccak256(abi.encode(uint256(keccak256("fevertokens.storage.ERC165")) - 1)) & ~bytes32(uint256(0xff));
 
     function layout() internal pure returns (Layout storage l) {

--- a/contracts/metatx/ERC2771Context.sol
+++ b/contracts/metatx/ERC2771Context.sol
@@ -21,7 +21,9 @@ contract ERC2771Context is IERC2771Context, ERC2771ContextInternal {
     /**
      * @inheritdoc IERC2771Context
      */
-    function isTrustedForwarder(address forwarder) public view virtual returns (bool) {
+    function isTrustedForwarder(
+        address forwarder
+    ) public view virtual returns (bool) {
         return _isTrustedForwarder(forwarder);
     }
 }

--- a/contracts/metatx/ERC2771ContextInternal.sol
+++ b/contracts/metatx/ERC2771ContextInternal.sol
@@ -6,7 +6,10 @@ pragma solidity 0.8.26;
 import {IERC2771ContextInternal} from "./IERC2771ContextInternal.sol";
 import {ContextInternal} from "./ContextInternal.sol";
 
-abstract contract ERC2771ContextInternal is IERC2771ContextInternal, ContextInternal {
+abstract contract ERC2771ContextInternal is
+    IERC2771ContextInternal,
+    ContextInternal
+{
     address internal _trustedForwarder;
 
     function __ERC2771Context_init() internal {
@@ -15,7 +18,9 @@ abstract contract ERC2771ContextInternal is IERC2771ContextInternal, ContextInte
 
     function __ERC2771Context_init_unchained() internal {}
 
-    function _isTrustedForwarder(address forwarder) internal view virtual returns (bool) {
+    function _isTrustedForwarder(
+        address forwarder
+    ) internal view virtual returns (bool) {
         return forwarder == _trustedForwarder;
     }
 
@@ -24,7 +29,13 @@ abstract contract ERC2771ContextInternal is IERC2771ContextInternal, ContextInte
      * a call is not performed by the trusted forwarder or the calldata length is less than
      * 20 bytes (an address length).
      */
-    function _msgSender() internal view virtual override returns (address sender) {
+    function _msgSender()
+        internal
+        view
+        virtual
+        override
+        returns (address sender)
+    {
         if (_isTrustedForwarder(msg.sender) && msg.data.length >= 20) {
             // The assembly code is more direct than the Solidity version using `abi.decode`.
             /// @solidity memory-safe-assembly
@@ -41,7 +52,13 @@ abstract contract ERC2771ContextInternal is IERC2771ContextInternal, ContextInte
      * a call is not performed by the trusted forwarder or the calldata length is less than
      * 20 bytes (an address length).
      */
-    function _msgData() internal view virtual override returns (bytes calldata) {
+    function _msgData()
+        internal
+        view
+        virtual
+        override
+        returns (bytes calldata)
+    {
         if (_isTrustedForwarder(msg.sender) && msg.data.length >= 20) {
             return msg.data[:msg.data.length - 20];
         } else {

--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -20,11 +20,19 @@ abstract contract Proxy is IProxy {
     fallback() external payable virtual {
         address implementation = _getImplementation();
 
-        if (!implementation.isContract()) revert("Proxy: Implementation Is Not Contract");
+        if (!implementation.isContract())
+            revert("Proxy: Implementation Is Not Contract");
 
         assembly {
             calldatacopy(0, 0, calldatasize())
-            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+            let result := delegatecall(
+                gas(),
+                implementation,
+                0,
+                calldatasize(),
+                0,
+                0
+            )
             returndatacopy(0, 0, returndatasize())
 
             switch result

--- a/contracts/security/PausableStorage.sol
+++ b/contracts/security/PausableStorage.sol
@@ -13,7 +13,8 @@ library PausableStorage {
      * @custom:storage-location erc7201:fevertokens.storage.Pausable
      */
     //
-    bytes32 internal constant STORAGE_SLOT = 0xebcd51003fd5533c59513c252620a545fc9897054eca22522368fea01d3dcc00;
+    bytes32 internal constant STORAGE_SLOT =
+        0xebcd51003fd5533c59513c252620a545fc9897054eca22522368fea01d3dcc00;
     // keccak256(abi.encode(uint256(keccak256("fevertokens.storage.Pausable")) - 1)) & ~bytes32(uint256(0xff));
 
     function layout() internal pure returns (Layout storage l) {

--- a/contracts/security/ReentrancyGuard.sol
+++ b/contracts/security/ReentrancyGuard.sol
@@ -22,4 +22,7 @@ import {ReentrancyGuardInternal} from "./ReentrancyGuardInternal.sol";
  * to protect against it, check out our blog post
  * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
  */
-abstract contract ReentrancyGuard is IReentrancyGuard, ReentrancyGuardInternal {}
+abstract contract ReentrancyGuard is
+    IReentrancyGuard,
+    ReentrancyGuardInternal
+{}

--- a/contracts/security/ReentrancyGuardInternal.sol
+++ b/contracts/security/ReentrancyGuardInternal.sol
@@ -10,7 +10,10 @@ import {InitializableInternal} from "../initializable/InitializableInternal.sol"
 /**
  * @title Internal functions for ReeantrancyGuard security control module.
  */
-abstract contract ReentrancyGuardInternal is IReentrancyGuardInternal, InitializableInternal {
+abstract contract ReentrancyGuardInternal is
+    IReentrancyGuardInternal,
+    InitializableInternal
+{
     // Booleans are more expensive than uint256 or any type that takes up a full
     // word because each write operation emits an extra SLOAD to first read the
     // slot's contents, replace the bits taken up by the boolean, and then write
@@ -30,7 +33,8 @@ abstract contract ReentrancyGuardInternal is IReentrancyGuardInternal, Initializ
     }
 
     function __ReentrancyGuard_init_unchained() internal {
-        ReentrancyGuardStorage.Layout storage l = ReentrancyGuardStorage.layout();
+        ReentrancyGuardStorage.Layout storage l = ReentrancyGuardStorage
+            .layout();
         l.status = _NOT_ENTERED;
     }
 

--- a/contracts/security/ReentrancyGuardStorage.sol
+++ b/contracts/security/ReentrancyGuardStorage.sol
@@ -13,7 +13,8 @@ library ReentrancyGuardStorage {
      * @custom:storage-location erc7201:fevertokens.storage.ReentrancyGuard
      */
     //
-    bytes32 internal constant STORAGE_SLOT = 0x00819acec55f767aa17d67e128b36718f254b1fc532bb62897fe40fd70a5d100;
+    bytes32 internal constant STORAGE_SLOT =
+        0x00819acec55f767aa17d67e128b36718f254b1fc532bb62897fe40fd70a5d100;
     // keccak256(abi.encode(uint256(keccak256("fevertokens.storage.ReentrancyGuard")) - 1)) & ~bytes32(uint256(0xff));
 
     function layout() internal pure returns (Layout storage l) {

--- a/contracts/signature/EIP712Internal.sol
+++ b/contracts/signature/EIP712Internal.sol
@@ -15,7 +15,9 @@ import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
  */
 abstract contract EIP712Internal is IEIP712Internal, InitializableInternal {
     bytes32 private constant TYPE_HASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+        keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
 
     /**
      * @dev Initializes the domain separator and parameter caches.
@@ -64,9 +66,18 @@ abstract contract EIP712Internal is IEIP712Internal, InitializableInternal {
 
         // If the hashed name and version in storage are non-zero, the contract hasn't been properly initialized
         // and the EIP712 domain is not reliable, as it will be missing name and version.
-        if ($._hashedName != 0 || $._hashedVersion != 0) revert EIP712Uninitialized();
+        if ($._hashedName != 0 || $._hashedVersion != 0)
+            revert EIP712Uninitialized();
 
-        return (hex"0f", _EIP712Name(), _EIP712Version(), block.chainid, address(this), bytes32(0), new uint256[](0));
+        return (
+            hex"0f",
+            _EIP712Name(),
+            _EIP712Version(),
+            block.chainid,
+            address(this),
+            bytes32(0),
+            new uint256[](0)
+        );
     }
 
     /**
@@ -80,15 +91,27 @@ abstract contract EIP712Internal is IEIP712Internal, InitializableInternal {
      * @dev Builds the domain separator for the current chain.
      */
     function _buildDomainSeparator() private view returns (bytes32) {
-        return keccak256(abi.encode(TYPE_HASH, _EIP712NameHash(), _EIP712VersionHash(), block.chainid, address(this)));
+        return
+            keccak256(
+                abi.encode(
+                    TYPE_HASH,
+                    _EIP712NameHash(),
+                    _EIP712VersionHash(),
+                    block.chainid,
+                    address(this)
+                )
+            );
     }
 
     /**
      * @dev Given an already hashed struct, this function returns the hash of the fully encoded EIP712 message for this domain.
      * This hash can be used together with {ECDSA-recover} to obtain the signer of a message.
      */
-    function _hashTypedDataV4(bytes32 structHash) internal view returns (bytes32) {
-        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);
+    function _hashTypedDataV4(
+        bytes32 structHash
+    ) internal view returns (bytes32) {
+        return
+            MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);
     }
 
     /**

--- a/contracts/signature/EIP712Storage.sol
+++ b/contracts/signature/EIP712Storage.sol
@@ -28,7 +28,8 @@ library EIP712Storage {
      * @custom:storage-location erc7201:fevertokens.storage.EIP712
      */
     //
-    bytes32 internal constant STORAGE_SLOT = 0x25bd642bde6ccba30d90decc48cf28dd1d98433926125ed62a6aefecd15b0800;
+    bytes32 internal constant STORAGE_SLOT =
+        0x25bd642bde6ccba30d90decc48cf28dd1d98433926125ed62a6aefecd15b0800;
     // keccak256(abi.encode(uint256(keccak256("fevertokens.storage.EIP712")) - 1)) & ~bytes32(uint256(0xff));
 
     /**

--- a/contracts/utils/AddressUtils.sol
+++ b/contracts/utils/AddressUtils.sol
@@ -29,16 +29,34 @@ library AddressUtils {
         if (!success) revert("AddressUtils: Send Value Failed");
     }
 
-    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
-        return functionCall(target, data, "AddressUtils: failed low-level call");
+    function functionCall(
+        address target,
+        bytes memory data
+    ) internal returns (bytes memory) {
+        return
+            functionCall(target, data, "AddressUtils: failed low-level call");
     }
 
-    function functionCall(address target, bytes memory data, string memory error) internal returns (bytes memory) {
+    function functionCall(
+        address target,
+        bytes memory data,
+        string memory error
+    ) internal returns (bytes memory) {
         return _functionCallWithValue(target, data, 0, error);
     }
 
-    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
-        return functionCallWithValue(target, data, value, "AddressUtils: failed low-level call with value");
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value
+    ) internal returns (bytes memory) {
+        return
+            functionCallWithValue(
+                target,
+                data,
+                value,
+                "AddressUtils: failed low-level call with value"
+            );
     }
 
     function functionCallWithValue(
@@ -47,7 +65,8 @@ library AddressUtils {
         uint256 value,
         string memory error
     ) internal returns (bytes memory) {
-        if (value > address(this).balance) revert("AddressUtils: Insufficient Balance");
+        if (value > address(this).balance)
+            revert("AddressUtils: Insufficient Balance");
         return _functionCallWithValue(target, data, value, error);
     }
 
@@ -73,7 +92,15 @@ library AddressUtils {
 
         assembly {
             // execute external call via assembly to avoid automatic copying of return data
-            success := call(gasAmount, target, value, add(data, 0x20), mload(data), 0, 0)
+            success := call(
+                gasAmount,
+                target,
+                value,
+                add(data, 0x20),
+                mload(data),
+                0,
+                0
+            )
 
             // determine whether to limit amount of data to copy
             let toCopy := returndatasize()
@@ -98,7 +125,9 @@ library AddressUtils {
     ) private returns (bytes memory) {
         if (!isContract(target)) revert("AddressUtils: Not Contract");
 
-        (bool success, bytes memory returnData) = target.call{value: value}(data);
+        (bool success, bytes memory returnData) = target.call{value: value}(
+            data
+        );
 
         if (success) {
             return returnData;

--- a/contracts/utils/IMulticall.sol
+++ b/contracts/utils/IMulticall.sol
@@ -12,5 +12,7 @@ interface IMulticall {
      * @param data array of function call data payloads
      * @return results array of function call results
      */
-    function multicall(bytes[] calldata data) external returns (bytes[] memory results);
+    function multicall(
+        bytes[] calldata data
+    ) external returns (bytes[] memory results);
 }

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -12,12 +12,15 @@ abstract contract Multicall is IMulticall {
     /**
      * @inheritdoc IMulticall
      */
-    function multicall(bytes[] calldata data) external returns (bytes[] memory results) {
+    function multicall(
+        bytes[] calldata data
+    ) external returns (bytes[] memory results) {
         results = new bytes[](data.length);
 
         unchecked {
             for (uint256 i; i < data.length; i++) {
-                (bool success, bytes memory returndata) = address(this).delegatecall(data[i]);
+                (bool success, bytes memory returndata) = address(this)
+                    .delegatecall(data[i]);
 
                 if (success) {
                     results[i] = returndata;

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -52,33 +52,39 @@ library SafeCast {
     }
 
     function toInt128(int256 value) internal pure returns (int128) {
-        if (value < type(int128).min || value > type(int128).max) revert("SafeCast: Value Does Not Fit");
+        if (value < type(int128).min || value > type(int128).max)
+            revert("SafeCast: Value Does Not Fit");
 
         return int128(value);
     }
 
     function toInt64(int256 value) internal pure returns (int64) {
-        if (value < type(int64).min || value > type(int64).max) revert("SafeCast: Value Does Not Fit");
+        if (value < type(int64).min || value > type(int64).max)
+            revert("SafeCast: Value Does Not Fit");
         return int64(value);
     }
 
     function toInt32(int256 value) internal pure returns (int32) {
-        if (value < type(int32).min || value > type(int32).max) revert("SafeCast: Value Does Not Fit");
+        if (value < type(int32).min || value > type(int32).max)
+            revert("SafeCast: Value Does Not Fit");
         return int32(value);
     }
 
     function toInt16(int256 value) internal pure returns (int16) {
-        if (value < type(int16).min || value > type(int16).max) revert("SafeCast: Value Does Not Fit");
+        if (value < type(int16).min || value > type(int16).max)
+            revert("SafeCast: Value Does Not Fit");
         return int16(value);
     }
 
     function toInt8(int256 value) internal pure returns (int8) {
-        if (value < type(int8).min || value > type(int8).max) revert("SafeCast: Value Does Not Fit");
+        if (value < type(int8).min || value > type(int8).max)
+            revert("SafeCast: Value Does Not Fit");
         return int8(value);
     }
 
     function toInt256(uint256 value) internal pure returns (int256) {
-        if (value > uint256(type(int256).max)) revert("SafeCast: Value Does Not Fit");
+        if (value > uint256(type(int256).max))
+            revert("SafeCast: Value Does Not Fit");
         return int256(value);
     }
 }

--- a/contracts/utils/UintUtils.sol
+++ b/contracts/utils/UintUtils.sol
@@ -60,7 +60,10 @@ library UintUtils {
         return toHexString(value, length);
     }
 
-    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {
+    function toHexString(
+        uint256 value,
+        uint256 length
+    ) internal pure returns (string memory) {
         bytes memory buffer = new bytes(2 * length + 2);
         buffer[0] = "0";
         buffer[1] = "x";


### PR DESCRIPTION
… across EnumerableMap, EnumerableSet, IncrementalMerkleTree, Initializable, ERC165, ERC2771Context, Proxy, and utility libraries.

Adjusted formatting for multi-line parameters and added spacing for clarity.

Updated storage slot constants for better alignment.

Enhanced error handling in SafeCast and AddressUtils.

That's only the result of running `pnpm lint:fix`